### PR TITLE
Fix installation issue on gnome-terminal 3.22 or later

### DIFF
--- a/terminals/gnome-terminal/src/tools.sh
+++ b/terminals/gnome-terminal/src/tools.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
+gnomeVersion="$(expr \
+    "$(LANGUAGE=en_US.UTF-8 gnome-terminal --version)" : \
+    '^[^[:digit:]]* \(\([[:digit:]]*\.*\)*\)' \
+)"
 
 # newGnome=1 if the gnome-terminal version >= 3.8
 if [[ ("$(echo "$gnomeVersion" | cut -d"." -f1)" = "3" && \


### PR DESCRIPTION
This PR will fix installation issue on gnome-terminal 3.22 or later.

Current behavior:
Installation failed.
The same issue as https://github.com/aruhier/gnome-terminal-colors-solarized/issues/63 occurred.
```
$ LANGUAGE=en_US.UTF-8 gnome-terminal --version
# GNOME Terminal 3.42.2 using VTE 0.66.2 +BIDI +GNUTLS +ICU +SYSTEMD
$ LANGUAGE=en_US.UTF-8 ./terminals/gnome-terminal/install.sh

Warning!
This will permanently overwrite colors in selected profile - there is no undo.
Consider creating a new profile before installing Selenized.

Please select Selenized variant:
1) selenized-black
2) selenized-dark
3) selenized-light
4) selenized-white
#? 1

Please select a Gnome Terminal profile:

You have selected:

  Scheme:  Selenized selenized-black
Failed to get value for `/apps/gnome-terminal/profiles//visible_name': Bad key or directory name: "/apps/gnome-terminal/profiles//visible_name": Can't have two slashes '/' in a row
  Profile: (No name) ()

Are you sure you want to overwrite the selected profile?
(YES to continue) ^C
```

After applying this patch:
Installation succeeded.
```
$ LANGUAGE=en_US.UTF-8 ./terminals/gnome-terminal/install.sh

Warning!
This will permanently overwrite colors in selected profile - there is no undo.
Consider creating a new profile before installing Selenized.

Please select Selenized variant:
1) selenized-black
2) selenized-dark
3) selenized-light
4) selenized-white
#? 1

Please select a Gnome Terminal profile:
1) default
2) selenized black
#? 2

You have selected:

  Scheme:  Selenized selenized-black
  Profile: selenized black (:dc9d2c2c-02a9-48b9-aefc-5e86f2270e02)

Are you sure you want to overwrite the selected profile?
(YES to continue) YES
Confirmation received -- applying settings
```

Note that this patch comes from upstream (https://github.com/aruhier/gnome-terminal-colors-solarized/commit/0d74f5a309fdff1e1316f9152d512530c75321e1). 
I am not the original author of this patch, and I just cherry-picked that commit.

The upstream repository is served under MIT license, and copyright notice and permission notice are already in this repository at [terminals/gnome-terminal/LICENSE.mkd](https://github.com/jan-warchol/selenized/blob/e93e0d9fb47c7485f18fa16f9bdb70c2ee7fb5db/terminals/gnome-terminal/LICENSE.mkd), so I think there is no problem.