### PR TITLE
Fix i3 configuration invalid and colors not read

### DIFF
--- a/other-apps/i3/i3-selenized-black.conf
+++ b/other-apps/i3/i3-selenized-black.conf
@@ -1,37 +1,37 @@
 # Selenized black colorscheme for i3
 # This must go in your i3 config
 
-set $bg #181818
-set $black #252525
-set $br_black #3b3b3b
-set $white #777777
-set $fg #b9b9b9
-set $br_white #dedede
+set $bg "#181818"
+set $black "#252525"
+set $br_black "#3b3b3b"
+set $white "#777777"
+set $fg "#b9b9b9"
+set $br_white "#dedede"
 
-set $red #ed4a46
-set $green #70b433
-set $yellow #dbb32d
-set $blue #368aeb
-set $magenta #eb6eb7
-set $cyan #3fc5b7
-set $orange #e67f43
-set $violet #a580e2
+set $red "#ed4a46"
+set $green "#70b433"
+set $yellow "#dbb32d"
+set $blue "#368aeb"
+set $magenta "#eb6eb7"
+set $cyan "#3fc5b7"
+set $orange "#e67f43"
+set $violet "#a580e2"
 
-set $br_red #ff5e56
-set $br_green #83c746
-set $br_yellow #efc541
-set $br_blue #4f9cfe
-set $br_magenta #ff81ca
-set $br_cyan #56d8c9
-set $br_orange #fa9153
-set $br_violet #b891f5
+set $br_red "#ff5e56"
+set $br_green "#83c746"
+set $br_yellow "#efc541"
+set $br_blue "#4f9cfe"
+set $br_magenta "#ff81ca"
+set $br_cyan "#56d8c9"
+set $br_orange "#fa9153"
+set $br_violet "#b891f5"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
         font pango:DejaVu Sans Mono 10
         #mode hide
-        status_command i3status --config ~/.config/i3/i3status.conf
+        status_command i3status #--config ~/.config/i3/i3status.conf
 
         colors {
             separator $blue

--- a/other-apps/i3/i3-selenized-dark.conf
+++ b/other-apps/i3/i3-selenized-dark.conf
@@ -1,37 +1,37 @@
 # Selenized dark colorscheme for i3
 # This must go in your i3 config
 
-set $bg #103c48
-set $black #184956
-set $br_black #2d5b69
-set $white #72898f
-set $fg #adbcbc
-set $br_white #cad8d9
+set $bg "#103c48"
+set $black "#184956"
+set $br_black "#2d5b69"
+set $white "#72898f"
+set $fg "#adbcbc"
+set $br_white "#cad8d9"
 
-set $red #fa5750
-set $green #75b938
-set $yellow #dbb32d
-set $blue #4695f7
-set $magenta #f275be
-set $cyan #41c7b9
-set $orange #ed8649
-set $violet #af88eb
+set $red "#fa5750"
+set $green "#75b938"
+set $yellow "#dbb32d"
+set $blue "#4695f7"
+set $magenta "#f275be"
+set $cyan "#41c7b9"
+set $orange "#ed8649"
+set $violet "#af88eb"
 
-set $br_red #ff665c
-set $br_green #84c747
-set $br_yellow #ebc13d
-set $br_blue #58a3ff
-set $br_magenta #ff84cd
-set $br_cyan #53d6c7
-set $br_orange #fd9456
-set $br_violet #bd96fa
+set $br_red "#ff665c"
+set $br_green "#84c747"
+set $br_yellow "#ebc13d"
+set $br_blue "#58a3ff"
+set $br_magenta "#ff84cd"
+set $br_cyan "#53d6c7"
+set $br_orange "#fd9456"
+set $br_violet "#bd96fa"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
         font pango:DejaVu Sans Mono 10
         #mode hide
-        status_command i3status --config ~/.config/i3/i3status.conf
+        status_command i3status #--config ~/.config/i3/i3status.conf
 
         colors {
             separator $blue

--- a/other-apps/i3/i3-selenized-light.conf
+++ b/other-apps/i3/i3-selenized-light.conf
@@ -1,37 +1,37 @@
 # Selenized light colorscheme for i3
 # This must go in your i3 config
 
-set $bg #fbf3db
-set $black #ece3cc
-set $br_black #d5cdb6
-set $white #909995
-set $fg #53676d
-set $br_white #3a4d53
+set $bg "#fbf3db"
+set $black "#ece3cc"
+set $br_black "#d5cdb6"
+set $white "#909995"
+set $fg "#53676d"
+set $br_white "#3a4d53"
 
-set $red #d2212d
-set $green #489100
-set $yellow #ad8900
-set $blue #0072d4
-set $magenta #ca4898
-set $cyan #009c8f
-set $orange #c25d1e
-set $violet #8762c6
+set $red "#d2212d"
+set $green "#489100"
+set $yellow "#ad8900"
+set $blue "#0072d4"
+set $magenta "#ca4898"
+set $cyan "#009c8f"
+set $orange "#c25d1e"
+set $violet "#8762c6"
 
-set $br_red #cc1729
-set $br_green #428b00
-set $br_yellow #a78300
-set $br_blue #006dce
-set $br_magenta #c44392
-set $br_cyan #00978a
-set $br_orange #bc5819
-set $br_violet #825dc0
+set $br_red "#cc1729"
+set $br_green "#428b00"
+set $br_yellow "#a78300"
+set $br_blue "#006dce"
+set $br_magenta "#c44392"
+set $br_cyan "#00978a"
+set $br_orange "#bc5819"
+set $br_violet "#825dc0"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
         font pango:DejaVu Sans Mono 10
         #mode hide
-        status_command i3status --config ~/.config/i3/i3status.conf
+        status_command i3status #--config ~/.config/i3/i3status.conf
 
         colors {
             separator $blue

--- a/other-apps/i3/i3-selenized-white.conf
+++ b/other-apps/i3/i3-selenized-white.conf
@@ -1,37 +1,37 @@
 # Selenized white colorscheme for i3
 # This must go in your i3 config
 
-set $bg #ffffff
-set $black #ebebeb
-set $br_black #cdcdcd
-set $white #878787
-set $fg #474747
-set $br_white #282828
+set $bg "#ffffff"
+set $black "#ebebeb"
+set $br_black "#cdcdcd"
+set $white "#878787"
+set $fg "#474747"
+set $br_white "#282828"
 
-set $red #d6000c
-set $green #1d9700
-set $yellow #c49700
-set $blue #0064e4
-set $magenta #dd0f9d
-set $cyan #00ad9c
-set $orange #d04a00
-set $violet #7f51d6
+set $red "#d6000c"
+set $green "#1d9700"
+set $yellow "#c49700"
+set $blue "#0064e4"
+set $magenta "#dd0f9d"
+set $cyan "#00ad9c"
+set $orange "#d04a00"
+set $violet "#7f51d6"
 
-set $br_red #bf0000
-set $br_green #008400
-set $br_yellow #af8500
-set $br_blue #0054cf
-set $br_magenta #c7008b
-set $br_cyan #009a8a
-set $br_orange #ba3700
-set $br_violet #6b40c3
+set $br_red "#bf0000"
+set $br_green "#008400"
+set $br_yellow "#af8500"
+set $br_blue "#0054cf"
+set $br_magenta "#c7008b"
+set $br_cyan "#009a8a"
+set $br_orange "#ba3700"
+set $br_violet "#6b40c3"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
         font pango:DejaVu Sans Mono 10
         #mode hide
-        status_command i3status --config ~/.config/i3/i3status.conf
+        status_command i3status #--config ~/.config/i3/i3status.conf
 
         colors {
             separator $blue

--- a/other-apps/i3/i3status-selenized-black.conf
+++ b/other-apps/i3/i3status-selenized-black.conf
@@ -9,9 +9,9 @@
 general {
         colors = true
         interval = 5
-        color_good = #70b433
-        color_degraded = #dbb32d
-        color_bad = #ed4a46
+        color_good = "#70b433"
+        color_degraded = "#dbb32d"
+        color_bad = "#ed4a46"
 }
 
 order += "ipv6"

--- a/other-apps/i3/i3status-selenized-dark.conf
+++ b/other-apps/i3/i3status-selenized-dark.conf
@@ -9,9 +9,9 @@
 general {
         colors = true
         interval = 5
-        color_good = #75b938
-        color_degraded = #dbb32d
-        color_bad = #fa5750
+        color_good = "#75b938"
+        color_degraded = "#dbb32d"
+        color_bad = "#fa5750"
 }
 
 order += "ipv6"

--- a/other-apps/i3/i3status-selenized-light.conf
+++ b/other-apps/i3/i3status-selenized-light.conf
@@ -9,9 +9,9 @@
 general {
         colors = true
         interval = 5
-        color_good = #489100
-        color_degraded = #ad8900
-        color_bad = #d2212d
+        color_good = "#489100"
+        color_degraded = "#ad8900"
+        color_bad = "#d2212d"
 }
 
 order += "ipv6"

--- a/other-apps/i3/i3status-selenized-white.conf
+++ b/other-apps/i3/i3status-selenized-white.conf
@@ -9,9 +9,9 @@
 general {
         colors = true
         interval = 5
-        color_good = #1d9700
-        color_degraded = #c49700
-        color_bad = #d6000c
+        color_good = "#1d9700"
+        color_degraded = "#c49700"
+        color_bad = "#d6000c"
 }
 
 order += "ipv6"


### PR DESCRIPTION
Under i3status v2.13 the selenized config files are invalid, because the hashtag `#` is interpreted as a start of a comment and not as the begin of a color code.

This commit quotes the values to make sure i3status interpretes these as colorcodes.
Currently i3 interprets the colorcodes correctly, but to make sure its future proof the colorcodes in the i3 configs have been also quoted.

Example:

	color_good = #70b433
Is interpreted as comment, i3status throws an error.

	color_good = "#70b433"
i3status correctly interprets the colorcode.