### PR TITLE
Add Windows Terminal scheme definitions

### DIFF
--- a/terminals/windows-terminal/README.md
+++ b/terminals/windows-terminal/README.md
@@ -1,0 +1,3 @@
+# Selenized color scheme for [Windows Terminal](http://apps.microsoft.com/detail/9n0dx20hk701)
+
+The JSON files in this directory each define a single variant of the Selenized color scheme. To install the scheme for Windows Terminal, their content may be added manually to the application's own `settings.json` file (located through the "Open JSON file" menu in the settings window) specifically to the the `schemes` array.

--- a/terminals/windows-terminal/selenized-black.json
+++ b/terminals/windows-terminal/selenized-black.json
@@ -1,0 +1,23 @@
+{
+    "background":  "#181818",
+    "black":  "#252525",
+    "blue":  "#368aeb",
+    "brightBlack":  "#3b3b3b",
+    "brightBlue":  "#4f9cfe",
+    "brightCyan":  "#56d8c9",
+    "brightGreen":  "#83c746",
+    "brightPurple":  "#ff81ca",
+    "brightRed":  "#ff5e56",
+    "brightWhite":  "#dedede",
+    "brightYellow":  "#efc541",
+    "cursorColor":  "#dedede",
+    "cyan":  "#3fc5b7",
+    "foreground":  "#b9b9b9",
+    "green":  "#70b433",
+    "name":  "Selenized Black",
+    "purple":  "#eb6eb7",
+    "red":  "#ed4a46",
+    "selectionBackground":  "#3b3b3b",
+    "white":  "#777777",
+    "yellow":  "#dbb32d"
+}

--- a/terminals/windows-terminal/selenized-dark.json
+++ b/terminals/windows-terminal/selenized-dark.json
@@ -1,0 +1,23 @@
+{
+    "background":  "#103C48",
+    "black":  "#184956",
+    "blue":  "#4695F7",
+    "brightBlack":  "#2D5B69",
+    "brightBlue":  "#58A3FF",
+    "brightCyan":  "#53D6C7",
+    "brightGreen":  "#84C747",
+    "brightPurple":  "#FF84CD",
+    "brightRed":  "#FF665C",
+    "brightWhite":  "#CAD8D9",
+    "brightYellow":  "#EBC13D",
+    "cursorColor":  "#CAD8D9",
+    "cyan":  "#41C7B9",
+    "foreground":  "#ADBCBC",
+    "green":  "#75B938",
+    "name":  "Selenized Dark",
+    "purple":  "#F275BE",
+    "red":  "#FA5750",
+    "selectionBackground":  "#2D5B69",
+    "white":  "#72898F",
+    "yellow":  "#DBB32D"
+}

--- a/terminals/windows-terminal/selenized-light.json
+++ b/terminals/windows-terminal/selenized-light.json
@@ -1,0 +1,23 @@
+{
+    "background":  "#fbf3db",
+    "black":  "#ece3cc",
+    "blue":  "#0072d4",
+    "brightBlack":  "#d5cdb6",
+    "brightBlue":  "#006dce",
+    "brightCyan":  "#00978a",
+    "brightGreen":  "#428b00",
+    "brightPurple":  "#c44392",
+    "brightRed":  "#cc1729",
+    "brightWhite":  "#3a4d53",
+    "brightYellow":  "#a78300",
+    "cursorColor":  "#3a4d53",
+    "cyan":  "#009c8f",
+    "foreground":  "#53676d",
+    "green":  "#489100",
+    "name":  "Selenized Light",
+    "purple":  "#ca4898",
+    "red":  "#d2212d",
+    "selectionBackground":  "#d5cdb6",
+    "white":  "#909995",
+    "yellow":  "#ad8900"
+}

--- a/terminals/windows-terminal/selenized-white.json
+++ b/terminals/windows-terminal/selenized-white.json
@@ -1,0 +1,23 @@
+{
+    "background":  "#ffffff",
+    "black":  "#ebebeb",
+    "blue":  "#0064e4",
+    "brightBlack":  "#cdcdcd",
+    "brightBlue":  "#0054cf",
+    "brightCyan":  "#009a8a",
+    "brightGreen":  "#008400",
+    "brightPurple":  "#c7008b",
+    "brightRed":  "#bf0000",
+    "brightWhite":  "#282828",
+    "brightYellow":  "#af8500",
+    "cursorColor":  "#282828",
+    "cyan":  "#00ad9c",
+    "foreground":  "#474747",
+    "green":  "#1d9700",
+    "name":  "Selenized White",
+    "purple":  "#dd0f9d",
+    "red":  "#d6000c",
+    "selectionBackground":  "#cdcdcd",
+    "white":  "#878787",
+    "yellow":  "#c49700"
+}


### PR DESCRIPTION
This adds one JSON file for each variant of the color scheme (black, dark, light and white) for use with the Windows Terminal (https://apps.microsoft.com/detail/9n0dx20hk701) application.

No installation is currently provided, unfortunately. A Powershell script I wrote in hopes of automating splicing in contents of the added files into to the application's settings file, quickly ran into JSON serialization issues present with at least the Windows' default Powershell version, so I had to cut my losses there. For now, this will have to do. One is expected to splice the JSON content from the added files into the settings file, using one's own method(s).