### PR TITLE
Update Midnight Commander installation README.md

### DIFF
--- a/other-apps/mc/README.md
+++ b/other-apps/mc/README.md
@@ -10,7 +10,7 @@ Installation
 Download skin file and set `MC_SKIN` env variable to point to it:
 
     mkdir -p $HOME/.mc/; cd $HOME/.mc/
-    wget https://raw.githubusercontent.com/jan-warchol/selenized/master/mc/selenized.ini
+    wget https://raw.githubusercontent.com/jan-warchol/selenized/master/other-apps/mc/selenized.ini
     echo "export MC_SKIN=$HOME/.mc/selenized.ini" >> $HOME/.bashrc
 
 Keep in mind that you need to restart your terminal or reload your `.bashrc`


### PR DESCRIPTION
Ensure that the installation instruction works again since the `mc` directory was moved one level down, beneath the `other-apps` directory.