### PR TITLE
Make light packaging changes to vscode theme

### DIFF
--- a/editors/visual-studio-code/README.md
+++ b/editors/visual-studio-code/README.md
@@ -10,8 +10,16 @@ Selenized for VS Code
 
 ### Installation
 
-1.  copy the contents of this directory into `~/.vscode/extensions/selenized`
-    folder
-1.  restart Code
-1.  open theme picker with `ctrl+K ctrl+T` (or using cogwheel button in lower
-    left corner) and search for "selenized".
+1. Install from the Extensions view in VS Code by searching for "Selenized".
+1. If installing from a local package, run `code --install-extension selenized-color-theme-<version>.vsix`
+    or use Command Palette: "Extensions: Install from VSIX...".
+1. Open the theme picker with `Ctrl+K Ctrl+T` and select one of the Selenized themes.
+
+### Manual Development Install (fallback)
+
+If you are testing local files directly without packaging a VSIX:
+
+1. Copy this directory to `~/.vscode/extensions/jan-warchol.selenized-color-theme`.
+    For VS Code Insiders use `~/.vscode-insiders/extensions/jan-warchol.selenized-color-theme`.
+1. Restart VS Code.
+1. Open the theme picker (`Ctrl+K Ctrl+T`) and search for "Selenized".

--- a/editors/visual-studio-code/package.json
+++ b/editors/visual-studio-code/package.json
@@ -1,10 +1,22 @@
 {
     "name": "selenized-color-theme",
+    "publisher": "Jan Warchoł",
     "displayName": "Selenized color theme",
     "description": "Color theme using selenized palette, with emphasis on readability and balanced lightness.",
-    "version": "0.2.0",
+    "version": "0.2.1",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/jan-warchol/selenized.git"
+    },
+    "homepage": "https://github.com/jan-warchol/selenized",
+    "keywords": [
+        "theme",
+        "color-theme",
+        "selenized"
+    ],
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.80.0"
     },
     "categories": [
         "Themes"


### PR DESCRIPTION
Given the changes in the extension manifest per https://code.visualstudio.com/api/references/extension-manifest, this commit incorporates those changes so that the theme can be installed manually without a VSIX package.

Closes: #115